### PR TITLE
CONW-225: Allow overriding fuse signup behaviour.

### DIFF
--- a/__tests__/pages/global.test.ts
+++ b/__tests__/pages/global.test.ts
@@ -16,7 +16,7 @@ describe('global events', () => {
   test('type definitions are inferred correctly by compiler', () => {
     document.addEventListener(p.WatchlistEvent, e => e.detail.value as number)
     document.addEventListener(p.FavoritesReady, e => e.detail as undefined)
-    document.addEventListener(p.FavoriteAddedEvent, e => e.detail.value as string)
+    document.addEventListener(p.FavoriteAddedEvent, e => e.detail.value as string && e.detail.fuseSignup as boolean | null)
     document.addEventListener(p.FavoriteRemovedEvent, e => e.detail.value as string)
     document.addEventListener(p.PcsUiShowOverlayEvent, e => e.detail.timeout as number)
     expect(true).toBeTruthy() // dummy assertion since compiler check is the real test

--- a/src/pages/global.ts
+++ b/src/pages/global.ts
@@ -35,6 +35,7 @@ export const FavoriteRemovedEvent = 'WATCHLIST:FAVORITE_REMOVED'
 export type FavoriteAddedEventPayload = {
   type: typeof FavoriteAddedEvent
   value: string
+  fuseSignup?: boolean
 }
 export type FavoriteRemovedEventPayload = {
   type: typeof FavoriteRemovedEvent


### PR DESCRIPTION
Adds an optional flag that allows overriding fuse signup behaviour.

This is needed to suppress showing the fuse popup in cases where a favorite is auto-added on the detailpage, but the popup should not be shown as we're redirecting directly to afterlead page.